### PR TITLE
Use HTTP to check time and block interact/build

### DIFF
--- a/bukkit/src/main/java/io/ibj/mcauthenticator/MCAuthenticator.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/MCAuthenticator.java
@@ -53,6 +53,8 @@ public final class MCAuthenticator extends JavaPlugin {
         registerEvent(new ConnectionEvent(this));
         registerEvent(new MoveEvent(this));
         registerEvent(new InventoryEvent(this));
+        registerEvent(new InteractEvent(this));
+        registerEvent(new BuildEvent(this));
 
         this.configurationFile = new File(getDataFolder(), "config.yml");
         reload();

--- a/bukkit/src/main/java/io/ibj/mcauthenticator/auth/RFC6238.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/auth/RFC6238.java
@@ -136,7 +136,7 @@ public class RFC6238 implements Authenticator {
     private void validateServerTime() {
         // Since 1.0.2
         try {
-            String TIME_SERVER = "https://icanhazepoch.com";
+            String TIME_SERVER = "http://icanhazepoch.com";
             HttpURLConnection timeCheckQuery =
                     (HttpURLConnection) new URL(TIME_SERVER).openConnection();
             timeCheckQuery.setReadTimeout(4000);

--- a/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/BuildEvent.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/BuildEvent.java
@@ -1,0 +1,36 @@
+package io.ibj.mcauthenticator.engine.events;
+
+import io.ibj.mcauthenticator.MCAuthenticator;
+import io.ibj.mcauthenticator.model.User;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+@RequiredArgsConstructor
+public class BuildEvent implements Listener {
+    private final MCAuthenticator instance;
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Player player = event.getPlayer();
+        User u = instance.getCache().get(player.getUniqueId());
+
+        if (u.authenticated()) return;
+
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        User u = instance.getCache().get(player.getUniqueId());
+
+        if (u.authenticated()) return;
+
+        event.setCancelled(true);
+    }
+}

--- a/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/InteractEvent.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/InteractEvent.java
@@ -1,0 +1,25 @@
+package io.ibj.mcauthenticator.engine.events;
+
+import io.ibj.mcauthenticator.MCAuthenticator;
+import io.ibj.mcauthenticator.model.User;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+@RequiredArgsConstructor
+public class InteractEvent implements Listener {
+    private final MCAuthenticator instance;
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        User u = instance.getCache().get(player.getUniqueId());
+
+        if (u.authenticated()) return;
+
+        event.setCancelled(true);
+    }
+}


### PR DESCRIPTION
Revert to HTTP because https://icanhazepoch.com uses a self-signed certificate which causes SSLHandshakeException.

Block player interact and block place/break while not authenticated.