### PR TITLE
Load before registering listeners to prevent exceptions during server startup

### DIFF
--- a/bukkit/src/main/java/io/ibj/mcauthenticator/MCAuthenticator.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/MCAuthenticator.java
@@ -49,15 +49,15 @@ public final class MCAuthenticator extends JavaPlugin {
         getCommand("auth").setExecutor(commandHandler);
         commandHandler.registerCommands();
 
+        this.configurationFile = new File(getDataFolder(), "config.yml");
+        reload();
+
         registerEvent(new ChatEvent(this));
         registerEvent(new ConnectionEvent(this));
         registerEvent(new MoveEvent(this));
         registerEvent(new InventoryEvent(this));
         registerEvent(new InteractEvent(this));
         registerEvent(new BuildEvent(this));
-
-        this.configurationFile = new File(getDataFolder(), "config.yml");
-        reload();
     }
 
     private void registerEvent(Listener listener) {


### PR DESCRIPTION
It throws NPE because datasource is not loaded yet