### PR TITLE
Set PlayerQuitEvent to MONITOR

### DIFF
--- a/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/ConnectionEvent.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/ConnectionEvent.java
@@ -51,7 +51,7 @@ public final class ConnectionEvent implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onQuit(PlayerQuitEvent e) {
         User leave = instance.getCache().leave(e.getPlayer().getUniqueId());
         if (leave != null) {


### PR DESCRIPTION
Some plugins will drop items, etc. upon a player quitting. This will cause exceptions because the data has already been unloaded.