### PR TITLE
Fix NPE race condition

### DIFF
--- a/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/ChatEvent.java
+++ b/bukkit/src/main/java/io/ibj/mcauthenticator/engine/events/ChatEvent.java
@@ -28,7 +28,7 @@ public final class ChatEvent implements Listener {
             Iterator<Player> recipients = event.getRecipients().iterator();
             while(recipients.hasNext()) {
                 User u = instance.getCache().get(recipients.next().getUniqueId());
-                if(!u.authenticated()) recipients.remove();
+                if(u != null && !u.authenticated()) recipients.remove();
             }
             return;
         }


### PR DESCRIPTION
Since the chat event is async, NPE can occur if the chat message is sent at the same time as another player logs out.