### PR TITLE
Relocate shaded dependencies

### DIFF
--- a/universal/pom.xml
+++ b/universal/pom.xml
@@ -16,8 +16,42 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.4.3</version>
                 <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.google</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.warrenstrange.googleauth</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.googleauth</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.yubico</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.yubico</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.zaxxer.hikari</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.hikari</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>mkremins.fanciful</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.fanciful</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.amoebaman</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.amoebaman</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.apache</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.slf4j</pattern>
+                            <shadedPattern>io.ibj.mcauthenticator.libs.slf4j</shadedPattern>
+                        </relocation>
+                    </relocations>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Added relocation of the dependencies that get shaded into the plugin file to avoid issues that can occur when a dependency is already loaded with that package name but another version by another plugin or the server itself.